### PR TITLE
Add founder-updates email opt-in across onboarding, settings, and lan…

### DIFF
--- a/backend/alembic/versions/add_email_marketing_consent.py
+++ b/backend/alembic/versions/add_email_marketing_consent.py
@@ -1,0 +1,46 @@
+"""add email_marketing_consent and email_marketing_consent_at to users
+
+Revision ID: add_email_mkt_consent
+Revises: fix_history_sync_completed, rename_sub_price_cents
+Create Date: 2026-05-03
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "add_email_mkt_consent"
+down_revision: Union[str, Sequence[str], None] = (
+    "fix_history_sync_completed",
+    "rename_sub_price_cents",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "email_marketing_consent",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "email_marketing_consent_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "email_marketing_consent_at")
+    op.drop_column("users", "email_marketing_consent")

--- a/backend/db/users.py
+++ b/backend/db/users.py
@@ -41,6 +41,9 @@ class Users(SQLModel, table=True):
     # Plan / promo
     plan: str = Field(default="free", nullable=False)  # 'free' | 'promo' | 'paid'
     promo_code_used: str | None = Field(default=None, nullable=True)
+    # Marketing consent (founder updates)
+    email_marketing_consent: bool = Field(default=False, nullable=False)
+    email_marketing_consent_at: datetime | None = Field(default=None, nullable=True)
 
 class CoachClientLink(SQLModel, table=True):
     __tablename__ = "coach_client_link"

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,7 @@ from utils.config_utils import get_settings
 import database  # noqa: F401 - used for dependency injection
 from scheduler.background_scheduler import start_scheduler, stop_scheduler
 # Import routes
-from routes import email_routes, auth_routes, file_routes, users_routes, start_date_routes, job_applications_routes, coach_routes, onboarding_routes, stripe_webhook_routes, payment_routes
+from routes import email_routes, auth_routes, file_routes, users_routes, start_date_routes, job_applications_routes, coach_routes, onboarding_routes, stripe_webhook_routes, payment_routes, preferences_routes
 
 
 class OAuthRedactionFilter(logging.Filter):
@@ -107,6 +107,7 @@ app.include_router(coach_routes.router)
 app.include_router(onboarding_routes.router)
 app.include_router(stripe_webhook_routes.router)
 app.include_router(payment_routes.router)
+app.include_router(preferences_routes.router)
 
 limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter  # Ensure limiter is assigned

--- a/backend/routes/auth_routes.py
+++ b/backend/routes/auth_routes.py
@@ -330,7 +330,8 @@ async def getUser(request: Request, db_session: database.DBSession, user_id: str
         "sync_email_address": user.sync_email_address,
         "is_subscriber": (user.subscription_price_cents or 0) > 0,
         "subscribed_since": user.subscribed_at.isoformat() if user.subscribed_at else None,
-        "has_active_coach": active_coach_link is not None
+        "has_active_coach": active_coach_link is not None,
+        "email_marketing_consent": user.email_marketing_consent,
     }
 
 

--- a/backend/routes/preferences_routes.py
+++ b/backend/routes/preferences_routes.py
@@ -1,0 +1,119 @@
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from email_validator import validate_email, EmailNotValidError
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from sqlmodel import select
+
+import database
+from db.users import Users
+from session.session_layer import validate_session
+
+limiter = Limiter(key_func=get_remote_address)
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class EmailSignupRequest(BaseModel):
+    email: str
+
+
+class ConsentUpdateRequest(BaseModel):
+    consent: bool
+
+
+@router.post("/api/email-signup")
+@limiter.limit("5/minute")
+async def email_signup(
+    request: Request,
+    body: EmailSignupRequest,
+    db_session: database.DBSession,
+):
+    """Public landing-page email signup that captures founder-updates consent.
+
+    Creates a lightweight Users row if no user exists with this email; otherwise
+    flips the consent flag to True (preserving existing consent timestamp).
+
+    Always returns 200 to avoid email enumeration. Reconciles automatically with
+    a future Google OAuth login via the existing user_exists() helper.
+    """
+    try:
+        validated = validate_email(body.email, check_deliverability=False)
+        email_normalized = validated.normalized
+    except EmailNotValidError:
+        raise HTTPException(status_code=400, detail="Invalid email address")
+
+    existing = db_session.exec(
+        select(Users).where(Users.user_email == email_normalized)
+    ).first()
+
+    now = datetime.now(timezone.utc)
+
+    if existing:
+        if not existing.email_marketing_consent:
+            existing.email_marketing_consent = True
+            existing.email_marketing_consent_at = now
+            db_session.add(existing)
+            db_session.commit()
+            logger.info("email_signup: re-opted in existing user_email")
+    else:
+        new_user = Users(
+            user_id=str(uuid.uuid4()),
+            user_email=email_normalized,
+            start_date=None,
+            email_marketing_consent=True,
+            email_marketing_consent_at=now,
+        )
+        db_session.add(new_user)
+        db_session.commit()
+        logger.info("email_signup: created lite user record")
+
+    return {"ok": True}
+
+
+@router.put("/settings/email-marketing-consent")
+@limiter.limit("10/minute")
+async def update_email_marketing_consent(
+    request: Request,
+    body: ConsentUpdateRequest,
+    db_session: database.DBSession,
+    user_id: str = Depends(validate_session),
+):
+    """Set the authenticated user's founder-updates consent.
+
+    Timestamp tracks the CURRENT opted-in state, not historical consent:
+      - true,  was false -> flag=true,  timestamp=now()
+      - true,  was true  -> no-op
+      - false, was true  -> flag=false, timestamp=null
+      - false, was false -> no-op
+    """
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    user = db_session.get(Users, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if body.consent and not user.email_marketing_consent:
+        user.email_marketing_consent = True
+        user.email_marketing_consent_at = datetime.now(timezone.utc)
+        db_session.add(user)
+        db_session.commit()
+    elif not body.consent and user.email_marketing_consent:
+        user.email_marketing_consent = False
+        user.email_marketing_consent_at = None
+        db_session.add(user)
+        db_session.commit()
+
+    return {
+        "email_marketing_consent": user.email_marketing_consent,
+        "email_marketing_consent_at": (
+            user.email_marketing_consent_at.isoformat()
+            if user.email_marketing_consent_at
+            else None
+        ),
+    }

--- a/backend/tests/routes/test_preferences.py
+++ b/backend/tests/routes/test_preferences.py
@@ -1,0 +1,242 @@
+"""Tests for /api/email-signup and /settings/email-marketing-consent."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from sqlmodel import select
+
+from db.users import Users
+from db.utils.user_utils import user_exists
+
+
+class TestEmailMarketingConsent:
+    """PUT /settings/email-marketing-consent — authenticated consent toggle."""
+
+    def test_unauthenticated_returns_401(self, incognito_client):
+        resp = incognito_client.put(
+            "/settings/email-marketing-consent", json={"consent": True}
+        )
+        assert resp.status_code == 401
+
+    def test_opt_in_from_false_sets_flag_and_timestamp(
+        self, client_factory, logged_in_user
+    ):
+        client = client_factory(user=logged_in_user)
+        assert logged_in_user.email_marketing_consent is False
+        assert logged_in_user.email_marketing_consent_at is None
+
+        resp = client.put(
+            "/settings/email-marketing-consent", json={"consent": True}
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["email_marketing_consent"] is True
+        assert data["email_marketing_consent_at"] is not None
+
+    def test_opt_in_when_already_true_is_noop(
+        self, client_factory, logged_in_user, db_session
+    ):
+        client = client_factory(user=logged_in_user)
+        client.put("/settings/email-marketing-consent", json={"consent": True})
+
+        db_session.refresh(logged_in_user)
+        original_ts = logged_in_user.email_marketing_consent_at
+        assert original_ts is not None
+
+        resp = client.put(
+            "/settings/email-marketing-consent", json={"consent": True}
+        )
+
+        assert resp.status_code == 200
+        db_session.refresh(logged_in_user)
+        assert logged_in_user.email_marketing_consent is True
+        assert logged_in_user.email_marketing_consent_at == original_ts
+
+    def test_opt_out_nulls_timestamp(
+        self, client_factory, logged_in_user, db_session
+    ):
+        client = client_factory(user=logged_in_user)
+        client.put("/settings/email-marketing-consent", json={"consent": True})
+
+        resp = client.put(
+            "/settings/email-marketing-consent", json={"consent": False}
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["email_marketing_consent"] is False
+        assert data["email_marketing_consent_at"] is None
+
+        db_session.refresh(logged_in_user)
+        assert logged_in_user.email_marketing_consent is False
+        assert logged_in_user.email_marketing_consent_at is None
+
+    def test_opt_out_when_already_false_is_noop(
+        self, client_factory, logged_in_user
+    ):
+        client = client_factory(user=logged_in_user)
+
+        resp = client.put(
+            "/settings/email-marketing-consent", json={"consent": False}
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["email_marketing_consent"] is False
+        assert data["email_marketing_consent_at"] is None
+
+    def test_re_opt_in_after_opt_out_uses_new_timestamp(
+        self, client_factory, logged_in_user, db_session
+    ):
+        client = client_factory(user=logged_in_user)
+
+        client.put("/settings/email-marketing-consent", json={"consent": True})
+        db_session.refresh(logged_in_user)
+        first_ts = logged_in_user.email_marketing_consent_at
+
+        client.put("/settings/email-marketing-consent", json={"consent": False})
+
+        client.put("/settings/email-marketing-consent", json={"consent": True})
+        db_session.refresh(logged_in_user)
+        second_ts = logged_in_user.email_marketing_consent_at
+
+        assert logged_in_user.email_marketing_consent is True
+        assert second_ts is not None
+        assert second_ts != first_ts
+
+    def test_me_endpoint_includes_consent(self, client_factory, logged_in_user):
+        client = client_factory(user=logged_in_user)
+        client.put("/settings/email-marketing-consent", json={"consent": True})
+
+        resp = client.get("/me")
+        assert resp.status_code == 200
+        assert resp.json()["email_marketing_consent"] is True
+
+
+class TestEmailSignup:
+    """POST /api/email-signup — public landing-page form."""
+
+    def test_invalid_email_returns_400(self, incognito_client):
+        resp = incognito_client.post(
+            "/api/email-signup", json={"email": "not-an-email"}
+        )
+        assert resp.status_code == 400
+
+    def test_new_email_creates_lite_user_with_consent(
+        self, incognito_client, db_session
+    ):
+        resp = incognito_client.post(
+            "/api/email-signup", json={"email": "lianna@example.com"}
+        )
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+        user = db_session.exec(
+            select(Users).where(Users.user_email == "lianna@example.com")
+        ).first()
+        assert user is not None
+        assert user.email_marketing_consent is True
+        assert user.email_marketing_consent_at is not None
+        assert user.role == ""
+        assert user.onboarding_completed_at is None
+        assert user.has_email_sync_configured is False
+
+    def test_existing_user_with_consent_false_is_opted_in(
+        self, incognito_client, user_factory, db_session
+    ):
+        existing = user_factory(
+            user_id="existing1",
+            user_email="existing@example.com",
+            role="jobseeker",
+        )
+        assert existing.email_marketing_consent is False
+
+        resp = incognito_client.post(
+            "/api/email-signup", json={"email": "existing@example.com"}
+        )
+        assert resp.status_code == 200
+
+        db_session.refresh(existing)
+        assert existing.email_marketing_consent is True
+        assert existing.email_marketing_consent_at is not None
+        # Other fields untouched
+        assert existing.user_id == "existing1"
+        assert existing.role == "jobseeker"
+
+    def test_existing_consenting_user_timestamp_preserved(
+        self, incognito_client, user_factory, db_session
+    ):
+        original_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        existing = user_factory(
+            user_id="opted",
+            user_email="opted@example.com",
+            role="jobseeker",
+        )
+        existing.email_marketing_consent = True
+        existing.email_marketing_consent_at = original_ts
+        db_session.add(existing)
+        db_session.commit()
+
+        resp = incognito_client.post(
+            "/api/email-signup", json={"email": "opted@example.com"}
+        )
+        assert resp.status_code == 200
+
+        db_session.refresh(existing)
+        assert existing.email_marketing_consent is True
+        assert existing.email_marketing_consent_at == original_ts
+
+    def test_no_duplicate_row_on_repeat_signup(
+        self, incognito_client, db_session
+    ):
+        incognito_client.post(
+            "/api/email-signup", json={"email": "twice@example.com"}
+        )
+        incognito_client.post(
+            "/api/email-signup", json={"email": "twice@example.com"}
+        )
+
+        rows = db_session.exec(
+            select(Users).where(Users.user_email == "twice@example.com")
+        ).all()
+        assert len(rows) == 1
+
+
+class TestEmailSignupOAuthReconciliation:
+    """The critical end-to-end: lite signup then OAuth merges by email."""
+
+    def test_oauth_after_email_signup_preserves_consent(
+        self, incognito_client, db_session
+    ):
+        # 1. Sign up via landing page
+        incognito_client.post(
+            "/api/email-signup", json={"email": "merge@example.com"}
+        )
+        lite = db_session.exec(
+            select(Users).where(Users.user_email == "merge@example.com")
+        ).first()
+        assert lite is not None
+        original_consent_ts = lite.email_marketing_consent_at
+        original_user_id = lite.user_id
+
+        # 2. Simulate Google OAuth callback for the same email with Google's `sub`
+        google_sub = "google-oauth-sub-12345"
+        oauth_user = SimpleNamespace(
+            user_id=google_sub,
+            user_email="merge@example.com",
+        )
+        existing_user, _ = user_exists(oauth_user, db_session)
+
+        # 3. Assertions: row reconciled, consent preserved
+        assert existing_user is not None
+        assert existing_user.user_id == google_sub
+        assert existing_user.user_id != original_user_id
+        assert existing_user.email_marketing_consent is True
+        assert existing_user.email_marketing_consent_at == original_consent_ts
+
+        # 4. Single row, no duplicate
+        all_rows = db_session.exec(
+            select(Users).where(Users.user_email == "merge@example.com")
+        ).all()
+        assert len(all_rows) == 1

--- a/backend/tests/routes/test_preferences.py
+++ b/backend/tests/routes/test_preferences.py
@@ -3,10 +3,29 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+import pytest
 from sqlmodel import select
 
 from db.users import Users
 from db.utils.user_utils import user_exists
+
+
+@pytest.fixture(autouse=True)
+def disable_rate_limiting():
+    """SlowAPI counters share a single in-process store across tests, so the
+    real-world limits would block legitimate test traffic. Disable per-test."""
+    from routes.preferences_routes import limiter
+
+    limiter.enabled = False
+    yield
+    limiter.enabled = True
+
+
+def _strip_tz(dt):
+    """SQLite's DateTime backend drops tzinfo; normalize for equality checks."""
+    if dt is None:
+        return None
+    return dt.replace(tzinfo=None) if dt.tzinfo else dt
 
 
 class TestEmailMarketingConsent:
@@ -185,7 +204,7 @@ class TestEmailSignup:
 
         db_session.refresh(existing)
         assert existing.email_marketing_consent is True
-        assert existing.email_marketing_consent_at == original_ts
+        assert _strip_tz(existing.email_marketing_consent_at) == _strip_tz(original_ts)
 
     def test_no_duplicate_row_on_repeat_signup(
         self, incognito_client, db_session

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@heroui/react";
 import posthog from "posthog-js";
 
+import FounderUpdatesOptIn from "@/components/FounderUpdatesOptIn";
 import { GoogleIcon } from "@/components/icons";
 import { Navbar } from "@/components/navbar";
 import Spinner from "@/components/spinner";
@@ -108,6 +109,9 @@ function OnboardingContent() {
 	const [previewLimited, setPreviewLimited] = useState(false);
 	const [isLoadingPreview, setIsLoadingPreview] = useState(false);
 	const [previewError, setPreviewError] = useState<string | null>(null);
+
+	// Founder-updates opt-in (shown on step4a-i and step4a-ii)
+	const [founderUpdatesOptIn, setFounderUpdatesOptIn] = useState(false);
 
 	// Step 4 state
 	const [applicationsFound, setApplicationsFound] = useState(0);
@@ -408,6 +412,17 @@ function OnboardingContent() {
 	};
 
 	const handleGoToDashboard = async () => {
+		if (founderUpdatesOptIn) {
+			fetch(`${apiUrl}/settings/email-marketing-consent`, {
+				method: "PUT",
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ consent: true })
+			}).catch(() => {
+				// fire-and-forget — don't block dashboard navigation on consent capture
+			});
+			posthog.capture("founder_updates_opt_in", { surface: "onboarding", screen });
+		}
 		try {
 			await fetch(`${apiUrl}/api/users/complete-onboarding`, {
 				method: "POST",
@@ -981,6 +996,12 @@ function OnboardingContent() {
 							<p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
 								Your entire search fits within your free window — nothing will be hidden.
 							</p>
+							<div className="mb-4 text-left">
+								<FounderUpdatesOptIn
+									checked={founderUpdatesOptIn}
+									onChange={setFounderUpdatesOptIn}
+								/>
+							</div>
 							<Button className="w-full" color="primary" size="lg" onPress={handleGoToDashboard}>
 								Go to my dashboard →
 							</Button>
@@ -1036,6 +1057,12 @@ function OnboardingContent() {
 								Free accounts show the most recent 30 days in the dashboard. As your search continues,
 								your view stays current — older entries roll out as new ones come in. Your full history
 								is always exportable via CSV.
+							</div>
+							<div className="mb-4 text-left">
+								<FounderUpdatesOptIn
+									checked={founderUpdatesOptIn}
+									onChange={setFounderUpdatesOptIn}
+								/>
 							</div>
 							<Button className="w-full mb-3" color="primary" size="lg" onPress={handleGoToDashboard}>
 								Go to my dashboard →

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -997,10 +997,7 @@ function OnboardingContent() {
 								Your entire search fits within your free window — nothing will be hidden.
 							</p>
 							<div className="mb-4 text-left">
-								<FounderUpdatesOptIn
-									checked={founderUpdatesOptIn}
-									onChange={setFounderUpdatesOptIn}
-								/>
+								<FounderUpdatesOptIn checked={founderUpdatesOptIn} onChange={setFounderUpdatesOptIn} />
 							</div>
 							<Button className="w-full" color="primary" size="lg" onPress={handleGoToDashboard}>
 								Go to my dashboard →
@@ -1059,10 +1056,7 @@ function OnboardingContent() {
 								is always exportable via CSV.
 							</div>
 							<div className="mb-4 text-left">
-								<FounderUpdatesOptIn
-									checked={founderUpdatesOptIn}
-									onChange={setFounderUpdatesOptIn}
-								/>
+								<FounderUpdatesOptIn checked={founderUpdatesOptIn} onChange={setFounderUpdatesOptIn} />
 							</div>
 							<Button className="w-full mb-3" color="primary" size="lg" onPress={handleGoToDashboard}>
 								Go to my dashboard →

--- a/frontend/app/onboarding/page.tsx
+++ b/frontend/app/onboarding/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { Button } from "@heroui/react";
 import posthog from "posthog-js";
 
-import FounderUpdatesOptIn from "@/components/FounderUpdatesOptIn";
+import FounderEmailCapture from "@/components/FounderEmailCapture";
 import { GoogleIcon } from "@/components/icons";
 import { Navbar } from "@/components/navbar";
 import Spinner from "@/components/spinner";
@@ -21,8 +21,7 @@ type Screen =
 	| "step3"
 	| "step3.5"
 	| "step4-scanning"
-	| "step4a-i"
-	| "step4a-ii"
+	| "step4a-done"
 	| "step4b-i"
 	| "step4b-ii"
 	| "empty-state";
@@ -50,6 +49,37 @@ function daysAgoDate(days: number) {
 	const d = new Date();
 	d.setDate(d.getDate() - days);
 	return d;
+}
+
+function statusPillClass(status: string) {
+	switch (status?.toLowerCase()) {
+		case "rejection":
+			return "bg-red-100 text-red-800 dark:bg-red-600 dark:text-white";
+		case "offer made":
+			return "bg-green-100 text-green-800 dark:bg-success dark:text-white";
+		case "application confirmation":
+			return "bg-blue-100 text-blue-800 dark:bg-primary dark:text-white";
+		case "availability request":
+			return "bg-emerald-100 text-emerald-800 dark:bg-emerald-600 dark:text-white";
+		case "information request":
+			return "bg-teal-100 text-teal-800 dark:bg-teal-600 dark:text-white";
+		case "assessment sent":
+			return "bg-yellow-100 text-yellow-800 dark:bg-yellow-600 dark:text-white";
+		case "interview invitation":
+			return "bg-cyan-100 text-cyan-800 dark:bg-cyan-600 dark:text-white";
+		case "did not apply - inbound request":
+			return "bg-purple-100 text-purple-800 dark:bg-purple-600 dark:text-white";
+		case "action required from company":
+			return "bg-lime-100 text-lime-800 dark:bg-lime-600 dark:text-white";
+		case "hiring freeze notification":
+			return "bg-orange-100 text-orange-800 dark:bg-orange-600 dark:text-white";
+		case "withdrew application":
+			return "bg-fuchsia-100 text-fuchsia-800 dark:bg-fuchsia-600 dark:text-white";
+		case "outreach":
+			return "bg-indigo-100 text-indigo-800 dark:bg-indigo-600 dark:text-white";
+		default:
+			return "bg-zinc-200 text-zinc-800 dark:bg-zinc-600 dark:text-white";
+	}
 }
 
 // ─── Progress bar ─────────────────────────────────────────────────────────────
@@ -110,8 +140,8 @@ function OnboardingContent() {
 	const [isLoadingPreview, setIsLoadingPreview] = useState(false);
 	const [previewError, setPreviewError] = useState<string | null>(null);
 
-	// Founder-updates opt-in (shown on step4a-i and step4a-ii)
-	const [founderUpdatesOptIn, setFounderUpdatesOptIn] = useState(false);
+	// Email capture submitted state (shown on step4a-done and empty-state)
+	const [emailSubmitted, setEmailSubmitted] = useState(false);
 
 	// Step 4 state
 	const [applicationsFound, setApplicationsFound] = useState(0);
@@ -179,8 +209,7 @@ function OnboardingContent() {
 						if (found === 0) {
 							setScreen("empty-state");
 						} else if (currentRole === "jobseeker") {
-							const withinWindow = startDateForCheck === null || startDateForCheck >= daysAgoDate(30);
-							setScreen(withinWindow ? "step4a-i" : "step4a-ii");
+							setScreen("step4a-done");
 						} else {
 							setScreen(currentPlan === "promo" ? "step4b-i" : "step4b-ii");
 						}
@@ -268,6 +297,34 @@ function OnboardingContent() {
 				return;
 			}
 
+			// Jobseekers: auto-start a 30-day scan instead of routing to the date picker
+			if (currentRole === "jobseeker") {
+				try {
+					await fetch(`${apiUrl}/settings/start-date`, {
+						method: "PUT",
+						credentials: "include",
+						headers: { "Content-Type": "application/json" },
+						body: JSON.stringify({
+							preset: "1_month",
+							fetch_order: "recent_first",
+							end_date: null
+						})
+					});
+					posthog.capture("onboarding_scan_started", {
+						role: "jobseeker",
+						plan: status.plan ?? "free",
+						source: "auto"
+					});
+					setScreen("step4-scanning");
+					startPolling(daysAgoDate(30), "jobseeker", status.plan ?? "free");
+				} catch {
+					// Fall back to the manual date picker on failure
+					setScreen("step3");
+				}
+				return;
+			}
+
+			// Coaches still pick a date range manually
 			setScreen("step3");
 		};
 
@@ -412,17 +469,6 @@ function OnboardingContent() {
 	};
 
 	const handleGoToDashboard = async () => {
-		if (founderUpdatesOptIn) {
-			fetch(`${apiUrl}/settings/email-marketing-consent`, {
-				method: "PUT",
-				credentials: "include",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ consent: true })
-			}).catch(() => {
-				// fire-and-forget — don't block dashboard navigation on consent capture
-			});
-			posthog.capture("founder_updates_opt_in", { surface: "onboarding", screen });
-		}
 		try {
 			await fetch(`${apiUrl}/api/users/complete-onboarding`, {
 				method: "POST",
@@ -577,7 +623,7 @@ function OnboardingContent() {
 				<Navbar />
 				<main className="flex-grow flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
 					<Card>
-						<ProgressBar step={1} />
+						<ProgressBar step={1} total={isCoach ? 3 : 2} />
 						<h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
 							{isCoach ? "Connect the Gmail from your past job search" : "Connect your inbox"}
 						</h1>
@@ -894,19 +940,24 @@ function OnboardingContent() {
 
 	// Screen 4 — Scanning
 	if (screen === "step4-scanning") {
+		const isJobseeker = role === "jobseeker";
 		// Calculate actual scan range for display
 		const thirtyDaysAgo = daysAgoDate(30);
-		// Free users selecting > 30 days get capped to last 30 days
+		// Jobseekers always scan the last 30 days; coaches pick their own range.
 		const isFreeWithLimitedRange = plan === "free" && savedStartDate && savedStartDate < thirtyDaysAgo;
-		const effectiveScanStart = isFreeWithLimitedRange ? thirtyDaysAgo : savedStartDate;
-		const effectiveScanEnd = savedEndDate ? new Date(savedEndDate) : new Date();
+		const effectiveScanStart = isJobseeker
+			? thirtyDaysAgo
+			: isFreeWithLimitedRange
+				? thirtyDaysAgo
+				: savedStartDate;
+		const effectiveScanEnd = isJobseeker ? new Date() : savedEndDate ? new Date(savedEndDate) : new Date();
 
 		return (
 			<>
 				<Navbar />
 				<main className="flex-grow flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
 					<Card>
-						<ProgressBar step={3} />
+						<ProgressBar step={isJobseeker ? 1 : 3} total={isJobseeker ? 2 : 3} />
 						<div className="text-center">
 							<Spinner />
 							<h1 className="text-xl font-bold text-gray-900 dark:text-white mt-4 mb-2">
@@ -952,132 +1003,74 @@ function OnboardingContent() {
 		);
 	}
 
-	// Screen 4A-i — Job seeker, within 30 days
-	if (screen === "step4a-i") {
-		return (
-			<>
-				<Navbar />
-				<main className="flex-grow flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
-					<Card>
-						<ProgressBar step={3} />
-						<div className="text-center">
-							<div className="text-4xl mb-3">✓</div>
-							<h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-								You&apos;re all set
-							</h1>
-							<p className="text-gray-500 dark:text-gray-400 text-sm mb-3">
-								We found{" "}
-								<span className="font-semibold text-gray-700 dark:text-gray-300">
-									{applicationsFound} job-related email
-									{applicationsFound !== 1 ? "s" : ""}
-								</span>
-							</p>
-							{foundEmailsPreview.length > 0 && (
-								<div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3 mb-4 text-left">
-									<ul className="space-y-2">
-										{foundEmailsPreview.map((email, idx) => (
-											<li key={idx} className="flex justify-between text-sm">
-												<span className="text-gray-700 dark:text-gray-300 truncate mr-2">
-													{email.company_name}
-												</span>
-												<span className="text-gray-500 dark:text-gray-400 text-xs whitespace-nowrap">
-													{email.application_status}
-												</span>
-											</li>
-										))}
-									</ul>
-									{applicationsFound > foundEmailsPreview.length && (
-										<p className="text-xs text-gray-400 mt-2 text-center">
-											+{applicationsFound - foundEmailsPreview.length} more
-										</p>
-									)}
-								</div>
-							)}
-							<p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
-								Your entire search fits within your free window — nothing will be hidden.
-							</p>
-							<div className="mb-4 text-left">
-								<FounderUpdatesOptIn checked={founderUpdatesOptIn} onChange={setFounderUpdatesOptIn} />
-							</div>
-							<Button className="w-full" color="primary" size="lg" onPress={handleGoToDashboard}>
-								Go to my dashboard →
-							</Button>
-						</div>
-					</Card>
-				</main>
-			</>
-		);
-	}
+	// Screen 4A-done — Job seeker results + email capture (replaces step4a-i / step4a-ii)
+	if (screen === "step4a-done") {
+		const previewLimit = 4;
+		const visiblePreview = foundEmailsPreview.slice(0, previewLimit);
+		const remaining = Math.max(0, applicationsFound - visiblePreview.length);
 
-	// Screen 4A-ii — Job seeker, beyond 30 days
-	if (screen === "step4a-ii") {
 		return (
 			<>
 				<Navbar />
 				<main className="flex-grow flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
 					<Card>
-						<ProgressBar step={3} />
-						<div className="text-center">
-							<div className="text-4xl mb-3">✓</div>
+						<ProgressBar step={2} total={2} />
+						<div className="text-center mb-5">
+							<div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-success/15 text-success text-3xl">
+								✓
+							</div>
 							<h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
-								You&apos;re all set
+								Your dashboard is ready
 							</h1>
-							<p className="text-gray-500 dark:text-gray-400 text-sm mb-3">
-								We found{" "}
-								<span className="font-semibold text-gray-700 dark:text-gray-300">
-									{applicationsFound} job-related email
+							<p className="text-gray-500 dark:text-gray-400 text-sm">
+								<span className="font-semibold text-gray-800 dark:text-gray-100">
+									{applicationsFound} recruiter message
 									{applicationsFound !== 1 ? "s" : ""}
-								</span>
-							</p>
-							{foundEmailsPreview.length > 0 && (
-								<div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3 mb-4 text-left">
-									<ul className="space-y-2">
-										{foundEmailsPreview.map((email, idx) => (
-											<li key={idx} className="flex justify-between text-sm">
-												<span className="text-gray-700 dark:text-gray-300 truncate mr-2">
-													{email.company_name}
-												</span>
-												<span className="text-gray-500 dark:text-gray-400 text-xs whitespace-nowrap">
-													{email.application_status}
-												</span>
-											</li>
-										))}
-									</ul>
-									{applicationsFound > foundEmailsPreview.length && (
-										<p className="text-xs text-gray-400 mt-2 text-center">
-											+{applicationsFound - foundEmailsPreview.length} more
-										</p>
-									)}
-								</div>
-							)}
-							<div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-3 mb-5 text-sm text-blue-800 dark:text-blue-200 text-left">
-								Free accounts show the most recent 30 days in the dashboard. As your search continues,
-								your view stays current — older entries roll out as new ones come in. Your full history
-								is always exportable via CSV.
-							</div>
-							<div className="mb-4 text-left">
-								<FounderUpdatesOptIn checked={founderUpdatesOptIn} onChange={setFounderUpdatesOptIn} />
-							</div>
-							<Button className="w-full mb-3" color="primary" size="lg" onPress={handleGoToDashboard}>
-								Go to my dashboard →
-							</Button>
-							<Button
-								className="w-full mb-3"
-								color="secondary"
-								size="lg"
-								variant="flat"
-								onPress={handleUpgrade}
-							>
-								Upgrade to Premium — $5/mo
-							</Button>
-							<p className="text-xs text-gray-400">
-								You can{" "}
-								<button className="underline text-blue-500" onClick={handleGoToDashboard}>
-									export all your data to CSV
-								</button>{" "}
-								at any time, for free.
+								</span>{" "}
+								found in the last 30 days
 							</p>
 						</div>
+
+						{visiblePreview.length > 0 && (
+							<ul className="space-y-2 mb-3">
+								{visiblePreview.map((email, idx) => (
+									<li
+										key={idx}
+										className="flex items-center justify-between gap-3 text-sm rounded-md px-3 py-2 bg-gray-50 dark:bg-gray-800"
+									>
+										<span className="text-gray-800 dark:text-gray-100 truncate">
+											{email.company_name}
+										</span>
+										<span
+											className={`text-xs font-medium px-2 py-0.5 rounded-full whitespace-nowrap ${statusPillClass(email.application_status)}`}
+										>
+											{email.application_status}
+										</span>
+									</li>
+								))}
+							</ul>
+						)}
+						{remaining > 0 && (
+							<p className="text-xs text-gray-400 mb-4 text-center">
+								+{remaining} more in your dashboard
+							</p>
+						)}
+
+						<hr className="my-5 border-gray-200 dark:border-gray-700" />
+
+						<div className="mb-5">
+							<FounderEmailCapture defaultEmail={userEmail} onSubmitted={() => setEmailSubmitted(true)} />
+						</div>
+
+						<Button
+							className="w-full"
+							color="primary"
+							size="lg"
+							variant={emailSubmitted ? "solid" : "bordered"}
+							onPress={handleGoToDashboard}
+						>
+							Go to my dashboard →
+						</Button>
 					</Card>
 				</main>
 			</>
@@ -1230,18 +1223,19 @@ function OnboardingContent() {
 
 	// Empty state — no emails found
 	if (screen === "empty-state") {
+		const isJobseeker = role === "jobseeker";
 		return (
 			<>
 				<Navbar />
 				<main className="flex-grow flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
 					<Card>
-						<ProgressBar step={3} />
+						<ProgressBar step={isJobseeker ? 2 : 3} total={isJobseeker ? 2 : 3} />
 						<div className="text-center">
 							<div className="text-4xl mb-3">📭</div>
 							<h1 className="text-xl font-bold text-gray-900 dark:text-white mb-2">
 								We didn&apos;t find any job-related emails
 							</h1>
-							<ul className="text-sm text-gray-500 dark:text-gray-400 text-left space-y-2 mb-6 mt-4">
+							<ul className="text-sm text-gray-500 dark:text-gray-400 text-left space-y-2 mb-5 mt-4">
 								<li>
 									• Is this the right Gmail account? You connected{" "}
 									<span className="font-medium text-gray-700 dark:text-gray-300">
@@ -1255,25 +1249,28 @@ function OnboardingContent() {
 									manually from the dashboard.
 								</li>
 							</ul>
-							<Button
-								className="w-full mb-3"
-								color="primary"
-								size="lg"
-								variant="flat"
-								onPress={handleConnectGmail}
-							>
-								Connect a different Gmail account
-							</Button>
-							<Button
-								className="w-full"
-								color="default"
-								size="lg"
-								variant="light"
-								onPress={handleGoToDashboard}
-							>
-								Go to dashboard anyway
-							</Button>
 						</div>
+						<div className="mb-5">
+							<FounderEmailCapture defaultEmail={userEmail} onSubmitted={() => setEmailSubmitted(true)} />
+						</div>
+						<Button
+							className="w-full mb-3"
+							color="primary"
+							size="lg"
+							variant="flat"
+							onPress={handleConnectGmail}
+						>
+							Connect a different Gmail account
+						</Button>
+						<Button
+							className="w-full"
+							color={emailSubmitted ? "primary" : "default"}
+							size="lg"
+							variant={emailSubmitted ? "solid" : "light"}
+							onPress={handleGoToDashboard}
+						>
+							Go to dashboard anyway
+						</Button>
 					</Card>
 				</main>
 			</>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Button } from "@heroui/react";
+import { Button, Input } from "@heroui/react";
+import posthog from "posthog-js";
 
 import { Navbar } from "@/components/navbar";
 import { PrivacyFirst } from "@/components/PrivacyFirst";
@@ -10,7 +11,40 @@ import { PrivacyFirst } from "@/components/PrivacyFirst";
 const Index = () => {
 	const [showImagePopup, setShowImagePopup] = useState(false);
 	const [popupImageSrc, setPopupImageSrc] = useState("");
+	const [founderEmail, setFounderEmail] = useState("");
+	const [founderEmailState, setFounderEmailState] = useState<
+		"idle" | "submitting" | "success" | "error"
+	>("idle");
 	const router = useRouter();
+	const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+
+	const handleFounderSignup = async (e: React.FormEvent) => {
+		e.preventDefault();
+		const email = founderEmail.trim();
+		if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+			setFounderEmailState("error");
+			return;
+		}
+		setFounderEmailState("submitting");
+		try {
+			const res = await fetch(`${apiUrl}/api/email-signup`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ email })
+			});
+			if (res.ok) {
+				setFounderEmailState("success");
+				setFounderEmail("");
+				posthog.capture("founder_updates_landing_signup", { success: true });
+			} else {
+				setFounderEmailState("error");
+				posthog.capture("founder_updates_landing_signup", { success: false });
+			}
+		} catch {
+			setFounderEmailState("error");
+			posthog.capture("founder_updates_landing_signup", { success: false });
+		}
+	};
 
 	const handleLogin = () => {
 		router.push(`/login`);
@@ -331,6 +365,45 @@ const Index = () => {
 							>
 								Login
 							</a>
+						</div>
+
+						<div className="mt-10 pt-8 border-t border-gray-200 dark:border-gray-700 text-left max-w-xl mx-auto">
+							<p className="text-sm text-foreground/70 mb-3">
+								Get behind-the-scenes email updates from the founder. Cat pictures are just as
+								likely as screenshots of features I&apos;m thinking about.
+							</p>
+							{founderEmailState === "success" ? (
+								<p className="text-sm text-primary font-medium">
+									Thanks — see you in your inbox.
+								</p>
+							) : (
+								<form className="flex flex-col sm:flex-row gap-2" onSubmit={handleFounderSignup}>
+									<Input
+										aria-label="Email address"
+										className="flex-grow"
+										isDisabled={founderEmailState === "submitting"}
+										placeholder="you@example.com"
+										type="email"
+										value={founderEmail}
+										onValueChange={(v) => {
+											setFounderEmail(v);
+											if (founderEmailState === "error") setFounderEmailState("idle");
+										}}
+									/>
+									<Button
+										color="primary"
+										isLoading={founderEmailState === "submitting"}
+										type="submit"
+									>
+										Send me updates
+									</Button>
+								</form>
+							)}
+							{founderEmailState === "error" && (
+								<p className="text-xs text-danger mt-2">
+									Hmm — that didn&apos;t work. Check the email and try again.
+								</p>
+							)}
 						</div>
 					</div>
 				</div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -12,9 +12,7 @@ const Index = () => {
 	const [showImagePopup, setShowImagePopup] = useState(false);
 	const [popupImageSrc, setPopupImageSrc] = useState("");
 	const [founderEmail, setFounderEmail] = useState("");
-	const [founderEmailState, setFounderEmailState] = useState<
-		"idle" | "submitting" | "success" | "error"
-	>("idle");
+	const [founderEmailState, setFounderEmailState] = useState<"idle" | "submitting" | "success" | "error">("idle");
 	const router = useRouter();
 	const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
@@ -369,13 +367,11 @@ const Index = () => {
 
 						<div className="mt-10 pt-8 border-t border-gray-200 dark:border-gray-700 text-left max-w-xl mx-auto">
 							<p className="text-sm text-foreground/70 mb-3">
-								Get behind-the-scenes email updates from the founder. Cat pictures are just as
-								likely as screenshots of features I&apos;m thinking about.
+								Get behind-the-scenes email updates from the founder. Cat pictures are just as likely as
+								screenshots of features I&apos;m thinking about.
 							</p>
 							{founderEmailState === "success" ? (
-								<p className="text-sm text-primary font-medium">
-									Thanks — see you in your inbox.
-								</p>
+								<p className="text-sm text-primary font-medium">Thanks — see you in your inbox.</p>
 							) : (
 								<form className="flex flex-col sm:flex-row gap-2" onSubmit={handleFounderSignup}>
 									<Input

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -314,7 +314,7 @@ function PricingContent() {
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
 									Free users see the last 30 days of job application emails in their dashboard. Your
-									full history is stored and unlocks immediately when you upgrade — no re-sync needed.
+									full history is stored and unlocks immediately when you upgrade.
 									And regardless of your plan, you can always export everything we’ve ever processed
 									for you via CSV.
 								</p>
@@ -324,14 +324,13 @@ function PricingContent() {
 									Is there a limit on how many emails get scanned?
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
-									Free accounts scan up to 500 emails per month, which resets on the 1st. Premium
-									accounts have a higher monthly buffer to keep our costs predictable — if you’re
+									Free accounts scan up to 500 emails per month, which resets on the 1st. <br></br> Premium
+									accounts have a higher monthly buffer to keep our costs predictable — <br></br> if you’re
 									hitting limits, email{" "}
 									<a className="underline" href="mailto:help@justajobapp.com">
 										help@justajobapp.com
 									</a>{" "}
-									and we’ll figure it out together. (And if you’re getting 5,000 job emails a month,
-									we’d love to chat about your search strategy too.)
+									and we’ll help you out.
 								</p>
 							</div>
 							<div>
@@ -339,8 +338,8 @@ function PricingContent() {
 									What are automatic updates?
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
-									We check your email twice a day so you never miss another recruiter message. Your
-									dashboard stays current without you having to manually refresh.
+									We check your email twice a day to stop you from missing recruiter messages. 
+									<br></br>Your dashboard stays current without you having to manually refresh.
 								</p>
 							</div>
 							<div>
@@ -348,7 +347,7 @@ function PricingContent() {
 									Can I cancel anytime?
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
-									Yes! You can cancel your subscription at any time. You'll keep premium features
+									Yes! You can cancel your subscription at any time in the Settings menu ⚙️. You'll keep premium features
 									until the end of your billing period.
 								</p>
 							</div>

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -324,8 +324,8 @@ function PricingContent() {
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
 									Free accounts scan up to 500 emails per month, which resets on the 1st. <br />{" "}
-									Premium accounts have a higher monthly buffer to keep our costs predictable —{" "}
-									<br /> if you’re hitting limits, email{" "}
+									Premium accounts have a higher monthly buffer to keep our costs predictable — <br />{" "}
+									if you’re hitting limits, email{" "}
 									<a className="underline" href="mailto:help@justajobapp.com">
 										help@justajobapp.com
 									</a>{" "}
@@ -337,8 +337,9 @@ function PricingContent() {
 									What are automatic updates?
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
-									We check your email twice a day to stop you from missing recruiter messages.
-									<br />Your dashboard stays current without you having to manually refresh.
+									We check your email twice a day to help you stop missing recruiter messages.
+									<br />
+									Your dashboard stays current without you wasting time in a messy inbox.
 								</p>
 							</div>
 							<div>

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -314,9 +314,8 @@ function PricingContent() {
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
 									Free users see the last 30 days of job application emails in their dashboard. Your
-									full history is stored and unlocks immediately when you upgrade.
-									And regardless of your plan, you can always export everything we’ve ever processed
-									for you via CSV.
+									full history is stored and unlocks immediately when you upgrade. And regardless of
+									your plan, you can always export everything we’ve ever processed for you via CSV.
 								</p>
 							</div>
 							<div>
@@ -324,9 +323,9 @@ function PricingContent() {
 									Is there a limit on how many emails get scanned?
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
-									Free accounts scan up to 500 emails per month, which resets on the 1st. <br></br> Premium
-									accounts have a higher monthly buffer to keep our costs predictable — <br></br> if you’re
-									hitting limits, email{" "}
+									Free accounts scan up to 500 emails per month, which resets on the 1st. <br />{" "}
+									Premium accounts have a higher monthly buffer to keep our costs predictable —{" "}
+									<br /> if you’re hitting limits, email{" "}
 									<a className="underline" href="mailto:help@justajobapp.com">
 										help@justajobapp.com
 									</a>{" "}
@@ -338,8 +337,8 @@ function PricingContent() {
 									What are automatic updates?
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
-									We check your email twice a day to stop you from missing recruiter messages. 
-									<br></br>Your dashboard stays current without you having to manually refresh.
+									We check your email twice a day to stop you from missing recruiter messages.
+									<br />Your dashboard stays current without you having to manually refresh.
 								</p>
 							</div>
 							<div>
@@ -347,8 +346,8 @@ function PricingContent() {
 									Can I cancel anytime?
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
-									Yes! You can cancel your subscription at any time in the Settings menu ⚙️. You'll keep premium features
-									until the end of your billing period.
+									Yes! You can cancel your subscription at any time in the Settings menu ⚙️. You'll
+									keep premium features until the end of your billing period.
 								</p>
 							</div>
 							<div>

--- a/frontend/app/pricing/page.tsx
+++ b/frontend/app/pricing/page.tsx
@@ -192,9 +192,7 @@ function PricingContent() {
 									</li>
 									<li className="flex items-start gap-2">
 										<XIcon className="w-5 h-5 text-default-400 mt-0.5 flex-shrink-0" />
-										<span className="text-gray-400 dark:text-gray-500">
-											Auto-refresh twice a day
-										</span>
+										<span className="text-gray-400 dark:text-gray-500">Automatic updates</span>
 									</li>
 								</ul>
 								<div className="mt-6">
@@ -239,9 +237,7 @@ function PricingContent() {
 									</li>
 									<li className="flex items-start gap-2">
 										<CheckIcon className="w-5 h-5 text-success mt-0.5 flex-shrink-0" />
-										<span className="text-gray-600 dark:text-gray-300">
-											Auto-refresh twice a day
-										</span>
+										<span className="text-gray-600 dark:text-gray-300">Automatic updates</span>
 									</li>
 								</ul>
 								<div className="mt-6">
@@ -340,11 +336,11 @@ function PricingContent() {
 							</div>
 							<div>
 								<h3 className="font-semibold text-gray-800 dark:text-white mb-2">
-									What does automatic sync do?
+									What are automatic updates?
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
-									With automatic sync, we check your email every 12 hours for new job application
-									updates. Your dashboard stays current without you having to manually refresh.
+									We check your email twice a day so you never miss another recruiter message. Your
+									dashboard stays current without you having to manually refresh.
 								</p>
 							</div>
 							<div>
@@ -362,7 +358,7 @@ function PricingContent() {
 								</h3>
 								<p className="text-gray-600 dark:text-gray-300">
 									No! If your coach has added you as a client, you automatically get premium features
-									including automatic sync at no extra cost.
+									including automatic updates at no extra cost.
 								</p>
 							</div>
 						</div>

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -96,7 +96,7 @@ const Footer = () => {
 							</>
 						) : (
 							<>
-								<p className="text-sm sm:text-base text-foreground">Stop missing recruiter emails</p>
+								<p className="text-sm sm:text-base text-foreground">Messy inbox? Stop losing recruiter emails.</p>
 								<button
 									className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary-600 transition-colors disabled:opacity-50"
 									disabled={isLoading}

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -96,7 +96,9 @@ const Footer = () => {
 							</>
 						) : (
 							<>
-								<p className="text-sm sm:text-base text-foreground">Messy inbox? Stop losing recruiter emails.</p>
+								<p className="text-sm sm:text-base text-foreground">
+									Messy inbox? Stop losing recruiter emails.
+								</p>
 								<button
 									className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary-600 transition-colors disabled:opacity-50"
 									disabled={isLoading}

--- a/frontend/components/Footer.tsx
+++ b/frontend/components/Footer.tsx
@@ -96,9 +96,7 @@ const Footer = () => {
 							</>
 						) : (
 							<>
-								<p className="text-sm sm:text-base text-foreground">
-									Your job search moves fast. Let your tracker keep up.
-								</p>
+								<p className="text-sm sm:text-base text-foreground">Stop missing recruiter emails</p>
 								<button
 									className="inline-flex items-center px-4 py-2 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:bg-primary-600 transition-colors disabled:opacity-50"
 									disabled={isLoading}

--- a/frontend/components/FounderEmailCapture.tsx
+++ b/frontend/components/FounderEmailCapture.tsx
@@ -69,15 +69,15 @@ export default function FounderEmailCapture({ defaultEmail = "", onSubmitted }: 
 		<div className="rounded-xl border-2 border-primary/40 bg-primary/5 dark:bg-primary/10 p-5">
 			<h2 className="text-lg font-bold text-foreground mb-2">Help me help your job search</h2>
 			<p className="text-sm text-foreground/80 mb-4 leading-relaxed">
-				Hi! I&apos;m Lianna, the gal building JustAJobApp. My mission is to save you from spreadsheet hell. 😈
-				Real human feedback can never be automated, so can I email you to ask awkward questions sometimes? 🥺
-				👉👈
+				Hi! I&apos;m Lianna, the gal building JustAJobApp. My mission is to save you from spreadsheet hell.
+				<br /> 😈 <br />Real human feedback can never be automated, so can I email you to ask awkward
+				questions sometimes? 🥺 👉👈
 			</p>
 			<form className="flex flex-col sm:flex-row gap-2" onSubmit={handleSubmit}>
 				<Input
 					ref={inputRef}
 					aria-label="Email address"
-					className="flex-grow"
+					className="flex-grow dark:focus:text-gray-800"
 					errorMessage={invalid ? "Please enter a valid email address" : undefined}
 					isDisabled={state === "submitting"}
 					isInvalid={invalid}

--- a/frontend/components/FounderEmailCapture.tsx
+++ b/frontend/components/FounderEmailCapture.tsx
@@ -70,8 +70,9 @@ export default function FounderEmailCapture({ defaultEmail = "", onSubmitted }: 
 			<h2 className="text-lg font-bold text-foreground mb-2">Help me help your job search</h2>
 			<p className="text-sm text-foreground/80 mb-4 leading-relaxed">
 				Hi! I&apos;m Lianna, the gal building JustAJobApp. My mission is to save you from spreadsheet hell.
-				<br /> 😈 <br />Real human feedback can never be automated, so can I email you to ask awkward
-				questions sometimes? 🥺 👉👈
+				<br /> 😈 <br />
+				Real human feedback can never be automated, so can I email you to ask awkward questions sometimes? 🥺
+				👉👈
 			</p>
 			<form className="flex flex-col sm:flex-row gap-2" onSubmit={handleSubmit}>
 				<Input

--- a/frontend/components/FounderEmailCapture.tsx
+++ b/frontend/components/FounderEmailCapture.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { Button, Input } from "@heroui/react";
+import posthog from "posthog-js";
+
+interface Props {
+	defaultEmail?: string;
+	onSubmitted?: () => void;
+}
+
+export default function FounderEmailCapture({ defaultEmail = "", onSubmitted }: Props) {
+	const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
+	const [email, setEmail] = useState(defaultEmail);
+	const [state, setState] = useState<"idle" | "submitting" | "success" | "error">("idle");
+	const [invalid, setInvalid] = useState(false);
+	const inputRef = useRef<HTMLInputElement | null>(null);
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		const value = email.trim();
+		if (!value || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+			setInvalid(true);
+			inputRef.current?.focus();
+			return;
+		}
+		setInvalid(false);
+		setState("submitting");
+		try {
+			const res = await fetch(`${apiUrl}/api/email-signup`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ email: value })
+			});
+			if (res.ok) {
+				setState("success");
+				posthog.capture("founder_email_capture", {
+					surface: "onboarding_step4a_done",
+					success: true
+				});
+				onSubmitted?.();
+			} else {
+				setState("error");
+				posthog.capture("founder_email_capture", {
+					surface: "onboarding_step4a_done",
+					success: false
+				});
+			}
+		} catch {
+			setState("error");
+			posthog.capture("founder_email_capture", {
+				surface: "onboarding_step4a_done",
+				success: false
+			});
+		}
+	};
+
+	if (state === "success") {
+		return (
+			<div className="rounded-xl border-2 border-primary/40 bg-primary/5 dark:bg-primary/10 p-5 text-center">
+				<div className="text-3xl mb-2">✓</div>
+				<p className="font-semibold text-foreground">Thanks — I&apos;ll be in touch</p>
+				<p className="text-sm text-foreground/70 mt-1">Lianna, founder of JustAJobApp</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="rounded-xl border-2 border-primary/40 bg-primary/5 dark:bg-primary/10 p-5">
+			<h2 className="text-lg font-bold text-foreground mb-2">Help me help your job search</h2>
+			<p className="text-sm text-foreground/80 mb-4 leading-relaxed">
+				Hi! I&apos;m Lianna, the gal building JustAJobApp. My mission is to save you from spreadsheet hell. 😈
+				Real human feedback can never be automated, so can I email you to ask awkward questions sometimes? 🥺
+				👉👈
+			</p>
+			<form className="flex flex-col sm:flex-row gap-2" onSubmit={handleSubmit}>
+				<Input
+					ref={inputRef}
+					aria-label="Email address"
+					className="flex-grow"
+					errorMessage={invalid ? "Please enter a valid email address" : undefined}
+					isDisabled={state === "submitting"}
+					isInvalid={invalid}
+					placeholder="you@email.com"
+					type="email"
+					value={email}
+					onValueChange={(v) => {
+						setEmail(v);
+						if (invalid) setInvalid(false);
+						if (state === "error") setState("idle");
+					}}
+				/>
+				<Button color="primary" isLoading={state === "submitting"} type="submit">
+					Email me
+				</Button>
+			</form>
+			<p className="text-xs text-foreground/60 mt-2">Occasional emails for feedback and new feature updates.</p>
+			{state === "error" && <p className="text-xs text-danger mt-2">Hmm — that didn&apos;t work. Try again?</p>}
+		</div>
+	);
+}

--- a/frontend/components/FounderUpdatesOptIn.tsx
+++ b/frontend/components/FounderUpdatesOptIn.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { Checkbox } from "@heroui/react";
+
+interface Props {
+	checked: boolean;
+	onChange: (checked: boolean) => void;
+}
+
+export default function FounderUpdatesOptIn({ checked, onChange }: Props) {
+	return (
+		<Checkbox
+			classNames={{
+				base: "items-start max-w-full",
+				label: "text-sm text-gray-600 dark:text-gray-400"
+			}}
+			isSelected={checked}
+			size="sm"
+			onValueChange={onChange}
+		>
+			Get behind-the-scenes email updates from the founder. Cat pictures are just as likely as
+			screenshots of features I&apos;m thinking about.
+		</Checkbox>
+	);
+}

--- a/frontend/components/FounderUpdatesOptIn.tsx
+++ b/frontend/components/FounderUpdatesOptIn.tsx
@@ -18,8 +18,8 @@ export default function FounderUpdatesOptIn({ checked, onChange }: Props) {
 			size="sm"
 			onValueChange={onChange}
 		>
-			Get behind-the-scenes email updates from the founder. Cat pictures are just as likely as
-			screenshots of features I&apos;m thinking about.
+			Get behind-the-scenes email updates from the founder. Cat pictures are just as likely as screenshots of
+			features I&apos;m thinking about.
 		</Checkbox>
 	);
 }

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -501,8 +501,8 @@ export default function SettingsModal({ isOpen, onClose, onSubscriptionChange }:
 								<div className="flex items-center justify-between">
 									<div className={!status.is_premium ? "opacity-50" : ""}>
 										<p className="font-medium text-foreground dark:text-white">Automatic updates</p>
-										<p className="text-sm text-foreground/60 dark:text-gray-400">
-											We check your email twice a day so you never miss another recruiter message
+										<p className="text-sm text-foreground/80 text-white dark:text-gray-300">
+											We check your email twice a day so you <br></br>stop missing recruiter messages
 										</p>
 									</div>
 									{status.is_premium ? (

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -502,8 +502,8 @@ export default function SettingsModal({ isOpen, onClose, onSubscriptionChange }:
 									<div className={!status.is_premium ? "opacity-50" : ""}>
 										<p className="font-medium text-foreground dark:text-white">Automatic updates</p>
 										<p className="text-sm text-foreground/80 text-white dark:text-gray-300">
-											We check your email twice a day so you <br />stop missing recruiter
-											messages
+											We check your email twice a day so you <br />
+											don't waste time combing through a messy inbox.
 										</p>
 									</div>
 									{status.is_premium ? (

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -10,7 +10,8 @@ import {
 	ModalFooter,
 	Spinner,
 	RadioGroup,
-	Radio
+	Radio,
+	Switch
 } from "@heroui/react";
 import posthog from "posthog-js";
 
@@ -64,6 +65,10 @@ export default function SettingsModal({ isOpen, onClose, onSubscriptionChange }:
 	const [isDeleting, setIsDeleting] = useState(false);
 	const [deleteConfirmText, setDeleteConfirmText] = useState("");
 
+	// Founder updates consent state
+	const [emailMarketingConsent, setEmailMarketingConsent] = useState(false);
+	const [isUpdatingConsent, setIsUpdatingConsent] = useState(false);
+
 	const apiUrl = process.env.NEXT_PUBLIC_API_URL!;
 
 	// Fetch premium status and user info when modal opens
@@ -81,9 +86,36 @@ export default function SettingsModal({ isOpen, onClose, onSubscriptionChange }:
 			if (response.ok) {
 				const data = await response.json();
 				setSyncEmail(data.sync_email_address || null);
+				setEmailMarketingConsent(Boolean(data.email_marketing_consent));
 			}
 		} catch (err) {
 			console.error("Error fetching user info:", err);
+		}
+	};
+
+	const handleConsentChange = async (newValue: boolean) => {
+		const previous = emailMarketingConsent;
+		setEmailMarketingConsent(newValue);
+		setIsUpdatingConsent(true);
+		try {
+			const response = await fetch(`${apiUrl}/settings/email-marketing-consent`, {
+				method: "PUT",
+				credentials: "include",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ consent: newValue })
+			});
+			if (!response.ok) {
+				setEmailMarketingConsent(previous);
+			} else {
+				posthog.capture("founder_updates_consent_changed", {
+					value: newValue,
+					surface: "settings"
+				});
+			}
+		} catch {
+			setEmailMarketingConsent(previous);
+		} finally {
+			setIsUpdatingConsent(false);
 		}
 	};
 
@@ -541,6 +573,26 @@ export default function SettingsModal({ isOpen, onClose, onSubscriptionChange }:
 										This will stop syncing new emails. Your existing data will remain.
 									</p>
 								)}
+							</div>
+
+							{/* Founder updates */}
+							<div className="border-t border-divider dark:border-[#3d5a3d] pt-4">
+								<div className="flex items-center justify-between gap-4">
+									<div>
+										<p className="font-medium text-foreground dark:text-white">
+											Email updates from the founder
+										</p>
+										<p className="text-sm text-foreground/60 dark:text-gray-400">
+											Behind-the-scenes notes via email from Lianna. May include cat pictures.
+										</p>
+									</div>
+									<Switch
+										aria-label="Email updates from the founder"
+										isDisabled={isUpdatingConsent}
+										isSelected={emailMarketingConsent}
+										onValueChange={handleConsentChange}
+									/>
+								</div>
 							</div>
 
 							{/* Delete Account */}

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -502,7 +502,8 @@ export default function SettingsModal({ isOpen, onClose, onSubscriptionChange }:
 									<div className={!status.is_premium ? "opacity-50" : ""}>
 										<p className="font-medium text-foreground dark:text-white">Automatic updates</p>
 										<p className="text-sm text-foreground/80 text-white dark:text-gray-300">
-											We check your email twice a day so you <br></br>stop missing recruiter messages
+											We check your email twice a day so you <br />stop missing recruiter
+											messages
 										</p>
 									</div>
 									{status.is_premium ? (

--- a/frontend/components/SettingsModal.tsx
+++ b/frontend/components/SettingsModal.tsx
@@ -491,18 +491,18 @@ export default function SettingsModal({ isOpen, onClose, onSubscriptionChange }:
 									</p>
 								) : !status.is_premium ? (
 									<p className="text-sm text-foreground/60 dark:text-gray-400">
-										Upgrade to unlock automatic background sync
+										Upgrade to unlock automatic updates
 									</p>
 								) : null}
 							</div>
 
-							{/* Background Sync */}
+							{/* Automatic updates */}
 							<div className="border-t border-divider dark:border-[#3d5a3d] pt-4">
 								<div className="flex items-center justify-between">
 									<div className={!status.is_premium ? "opacity-50" : ""}>
-										<p className="font-medium text-foreground dark:text-white">Background sync</p>
+										<p className="font-medium text-foreground dark:text-white">Automatic updates</p>
 										<p className="text-sm text-foreground/60 dark:text-gray-400">
-											Emails sync automatically every 12 hours
+											We check your email twice a day so you never miss another recruiter message
 										</p>
 									</div>
 									{status.is_premium ? (
@@ -580,14 +580,14 @@ export default function SettingsModal({ isOpen, onClose, onSubscriptionChange }:
 								<div className="flex items-center justify-between gap-4">
 									<div>
 										<p className="font-medium text-foreground dark:text-white">
-											Email updates from the founder
+											Emails from Lianna
 										</p>
 										<p className="text-sm text-foreground/60 dark:text-gray-400">
-											Behind-the-scenes notes via email from Lianna. May include cat pictures.
+											Occasional questions about your experience and new feature updates
 										</p>
 									</div>
 									<Switch
-										aria-label="Email updates from the founder"
+										aria-label="Emails from Lianna"
 										isDisabled={isUpdatingConsent}
 										isSelected={emailMarketingConsent}
 										onValueChange={handleConsentChange}


### PR DESCRIPTION

Captures email marketing consent in settings and onboarding flow.

<img width="2584" height="1786" alt="CleanShot 2026-05-31 at 17 09 37@2x" src="https://github.com/user-attachments/assets/eebb7283-ad64-47c3-94fc-fe3fff89fa46" />

- Onboarding: unchecked checkbox above the dashboard CTA on the jobseeker wow-moment screens (step4a-i, step4a-ii). Skipped on coach screens.
- Settings: switch toggle in a new "Email updates from the founder" section between Gmail and Delete Account. Reflects current persisted state.
- Landing: email-only signup form in the final CTA section for visitors who aren't ready to do Google OAuth.

Backend adds email_marketing_consent + email_marketing_consent_at to Users. Timestamp tracks the CURRENT opted-in state (nulled on opt-out, refreshed on re-opt-in) — no stale data after consent withdrawal.

Lite users created via the public landing-page endpoint reconcile cleanly when the same email later signs in with Google: the existing user_exists() helper matches by email and updates user_id to Google's sub, preserving consent fields and routing the user through onboarding normally.

init() now auto-fires PUT /settings/start-date with the 30-day preset for jobseekers post-OAuth instead of routing to the date picker; coach branch unchanged


https://claude.ai/code/session_01PG6SFkqg2M3xtmW7LudWnn

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license. 